### PR TITLE
完了: セッションリストの seeds 整備

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,46 +4,46 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: up
-up: ## make up
+up: ## docker-compose up -d
 	docker-compose up -d
 
 .PHONY: ps
-ps: ## make ps
+ps: ## docker-compose ps
 	docker-compose ps
 
 .PHONY: logs
-logs: ## make logs
+logs: ## docker-compose logs
 	docker-compose logs
 
 .PHONY: down
-down: ## make down
+down: ## docker-compose down -v
 	docker-compose down -v
 
 .PHONY: stop
-stop: ## make stop
+stop: ## docker-compose stop
 	docker-compose stop
 
 .PHONY: rebuild
-rebuild: ## make rebuild
+rebuild: ## docker-compose up -d --build
 	docker-compose up -d --build
 
 .PHONY: app
-app: ## make app
+app: ## docker-compose exec app /bin/bash
 	docker-compose exec app /bin/bash
 
 .PHONY: db
-db: ## make db
+db: ## docker-compose exec db /bin/bash
 	docker-compose exec db /bin/bash
 
 .PHONY: logapp
-logapp: ## make logapp
+logapp: ## docker-compose logs app
 	docker-compose logs app
 
 .PHONY: logdb
-logdb: ## make logdb
+logdb: ## docker-compose logs db
 	docker-compose logs db
 
 .PHONY: curl
-curl: ## make curl
+curl: ## curl -I http://localhost:4000
 	curl -I http://localhost:4000
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,19 @@ $ cat app/.env.tmpl > app/.env
 $ cat db/.env.tmpl > db/.env
 $ make rebuild  # docker-compose up -d --build
 
-# optional
-$ make ps #
-$ make
-$ make curl # curl -I http://localhost:4000 
+# How to use Makefile 
+$ make help
+up                   docker-compose up -d
+ps                   docker-compose ps
+logs                 docker-compose logs
+down                 docker-compose down -v
+stop                 docker-compose stop
+rebuild              docker-compose up -d --build
+app                  docker-compose exec app /bin/bash
+db                   docker-compose exec db /bin/bash
+logapp               docker-compose logs app
+logdb                docker-compose logs db
+curl                 curl -I http://localhost:4000
 ```
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ $ git clone https://github.com/youknowcast/jtfparty.git
 $ cat app/.env.tmpl > app/.env
 $ cat db/.env.tmpl > db/.env
 $ make rebuild  # docker-compose up -d --build
+
+# optional
+$ make ps #
+$ make
+$ make curl # curl -I http://localhost:4000 
 ```
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/app/scripts/docker-entrypoint.sh
+++ b/app/scripts/docker-entrypoint.sh
@@ -14,6 +14,7 @@ then
 fi
 
 cd $HOME \
+  && mix local.hex --force \
   && mix deps.get
 cd $HOME/assets \
   && npm install \
@@ -21,6 +22,7 @@ cd $HOME/assets \
 cd $HOME \
   && mix ecto.create \
   && mix ecto.migrate \
+  && mix run priv/repo/seeds.exs \
   && mix phx.server
 
 exec "$@"


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- app/scripts/docker-entrypoint.shでseeds整備
```
$ git diff app/scripts/docker-entrypoint.sh
diff --git a/app/scripts/docker-entrypoint.sh b/app/scripts/docker-entrypoint.sh

(略)
 
 cd $HOME \
+  && mix local.hex --force \
   && mix deps.get
 cd $HOME/assets \
   && npm install \
@@ -21,6 +22,7 @@ cd $HOME/assets \
 cd $HOME \
   && mix ecto.create \
   && mix ecto.migrate \
+  && mix run priv/repo/seeds.exs \
   && mix phx.server
 
 exec "$@"
```
- app/scripts/docker-entrypoint.shにmix local.hexを追記し、下記のエラー対処
```
Could not start Hex. Try fetching a new version with "mix local.hex" or uninstalling it with "mix archive.uninstall hex.ez"
```
参考：https://hexdocs.pm/mix/Mix.Tasks.Local.Hex.html

- Makefileのhelpの表示結果改善とREADME.mdに反映

```
$ make help
up                   docker-compose up -d
ps                   docker-compose ps
logs                 docker-compose logs
down                 docker-compose down -v
stop                 docker-compose stop
rebuild              docker-compose up -d --build
app                  docker-compose exec app /bin/bash
db                   docker-compose exec db /bin/bash
logapp               docker-compose logs app
logdb                docker-compose logs db
curl                 curl -I http://localhost:4000
``` 

